### PR TITLE
Readme Example - Plain JS `requires` instead of `imports`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,5 +54,12 @@ app.on('ready', () => {
 });
 ```
 
+### Requires with plain JavaScript
+
+```js
+const ElectronGoogleOAuth2 = require('@getstation/electron-google-oauth2').default;
+new ElectronGoogleOAuth2(CLIENT_ID, CLIENT_SECRET, SCOPES_LIST);
+```
+
 ## License
 MIT


### PR DESCRIPTION
Added readme example to show how to this library in plain JavaScript. Fixes #13 