### PR TITLE
Add a dispose method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,16 @@ class ElectronGoogleOAuth2 extends EventEmitter {
   setTokens(tokens: Credentials) {
     this.oauth2Client.setCredentials(tokens);
   }
+
+  /**
+   * Ensure that the server has been closed.
+   */
+  async dispose() {
+    if (this.server) {
+      await this.server.close();
+      this.server = null;
+    }
+  }
 }
 
 declare interface ElectronGoogleOAuth2 {


### PR DESCRIPTION
It is important to expose a way to abort the operation and close the server instance.

I have React code that creates a new `ElectronGoogleOAuth2` in a `useEffect` hook. If the user cancels the sign in (closes the browser tab) and/or navigates elsewhere in my app such that the component unmounts, then the server instance is left running forever. Even worse, the next attempt to log in fails, because the port is then occupied.

Adding a dispose method allows for me to handle this in the cleanup function of `useEffect`.

(note that the `server` property is technically accessible at runtime, but TypeScript doesn't like this, because it is `protected`)
