### PR TITLE
Use @electron/remote to get BrowserWindow

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "@electron/remote": "^2.0.8",
     "google-auth-library": "^5.9.2"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // inspired by https://github.com/parro-it/electron-google-oauth
-import { BrowserWindow, remote, shell } from 'electron';
+import { BrowserWindow, shell } from 'electron';
 import { EventEmitter } from 'events';
 import { OAuth2Client } from 'google-auth-library';
 import { Credentials } from 'google-auth-library/build/src/auth/credentials';
@@ -7,7 +7,8 @@ import { stringify } from 'querystring';
 import * as url from 'url';
 import LoopbackRedirectServer from './LoopbackRedirectServer';
 
-const BW: typeof BrowserWindow = process.type === 'renderer' ? remote.BrowserWindow : BrowserWindow;
+const BW: typeof BrowserWindow = process.type === 'renderer' ?
+  require('@electron/remote').BrowserWindow : BrowserWindow;
 
 export class UserClosedWindowError extends Error {
   constructor() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,11 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
+"@electron/remote@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.8.tgz#85ff321f0490222993207106e2f720273bb1a5c3"
+  integrity sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
Fixes #42

https://github.com/getstation/electron-google-oauth2/blob/c0bc8530de41ee86948ee792de8d2b278ecf99b0/src/index.ts#L10

The `remote` module was replaced by [`@electron/remote`](https://github.com/electron/remote) in Electron v14, I think we should use it also here.